### PR TITLE
3.16 修正內容

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -136,6 +136,7 @@
     <Compile Include="ExConfig\ConvertConfig.cs" />
     <Compile Include="ExConfig\CurrentConfig.cs" />
     <Compile Include="ExConfig\DefaultConfig.cs" />
+    <Compile Include="ExConfig\LoadDataConfig.cs" />
     <Compile Include="ExConfig\ProcessConfig.cs" />
     <Compile Include="ExportExcel.cs" />
     <Compile Include="Extension\ExtensionByteArray.cs" />

--- a/Common/Enums/AlarmTypes/AlarmTypes_Part02.cs
+++ b/Common/Enums/AlarmTypes/AlarmTypes_Part02.cs
@@ -237,12 +237,12 @@ namespace Common.Enums
         [AlarmInfo(717, 014)]
         M717 = 0x0020_0000_0000_0000,
 
-        [Display(ENG_: "718 -", ZHTW_: "718 -")]
-        [AlarmInfo(718)]
+        [Display(ENG_: "718 資料要求下載過早(150秒內)", ZHTW_: "718 資料要求下載過早(150秒內)")]
+        [AlarmInfo(718, 500)]
         M718 = 0x0040_0000_0000_0000,
 
-        [Display(ENG_: "719 -", ZHTW_: "719 -")]
-        [AlarmInfo(719, 000)]
+        [Display(ENG_: "719 批號變更批號比對異常 ", ZHTW_: "719 批號變更批號比對異常")]
+        [AlarmInfo(719, 501)]
         M719 = 0x0080_0000_0000_0000,
 
 

--- a/Common/Enums/AlarmTypes/AlarmTypes_Part02.cs
+++ b/Common/Enums/AlarmTypes/AlarmTypes_Part02.cs
@@ -237,7 +237,7 @@ namespace Common.Enums
         [AlarmInfo(717, 014)]
         M717 = 0x0020_0000_0000_0000,
 
-        [Display(ENG_: "718 資料要求下載過早(150秒內)", ZHTW_: "718 資料要求下載過早(150秒內)")]
+        [Display(ENG_: "718 LoadData結束時間差過短[PC計時]", ZHTW_: "718 LoadData結束時間差過短[PC計時]")]
         [AlarmInfo(718, 500)]
         M718 = 0x0040_0000_0000_0000,
 
@@ -267,7 +267,7 @@ namespace Common.Enums
         [AlarmInfo(724, 019)]
         M724 = 0x1000_0000_0000_0000,
 
-        [Display(ENG_: "725 -", ZHTW_: "725 -")]
+        [Display(ENG_: "725 CycleTimeEndTimeTooShort", ZHTW_: "725 LoadData結束時間差過短[PLC計時]")]
         [AlarmInfo(725)]
         M725 = 0x2000_0000_0000_0000,
 

--- a/Common/Enums/ExceptionTypes.cs
+++ b/Common/Enums/ExceptionTypes.cs
@@ -82,6 +82,11 @@ namespace Common.Enums
         [Description("MES相關-無此無塵衣ID紀錄")]
         WrongUserID = 0x007003,
         /// <summary>
+        /// MES相關-Type04-發生錯誤回報
+        /// </summary>
+        [Description("MES相關-發生錯誤回報")]
+        ErrorMsg = 0x007004,
+        /// <summary>
         /// 程式錯誤
         /// </summary>
         [Description("程式錯誤")]

--- a/Common/ExConfig/DefaultConfig.cs
+++ b/Common/ExConfig/DefaultConfig.cs
@@ -24,6 +24,23 @@ namespace Common.ExConfig
         }
         static CurrentConfig _CurrentConfig;
 
+
+        public static LoadDataConfig LoadDataConfig
+        {
+            get
+            {
+                if (_LoadDataConfig is null)
+                {
+                    _LoadDataConfig = new LoadDataConfig
+                    {
+                        LoadDataFinishAlarmSec = 150
+                    };
+                }
+                return _LoadDataConfig;
+            }
+        }
+        static LoadDataConfig _LoadDataConfig;
+
         public static ProcessConfig ProcessConfig
         {
             get

--- a/Common/ExConfig/LoadDataConfig.cs
+++ b/Common/ExConfig/LoadDataConfig.cs
@@ -1,0 +1,14 @@
+﻿using Common.Attributes;
+
+namespace Common.ExConfig
+{
+    public class LoadDataConfig
+    {
+        /// <summary>
+        /// LoadData結束警報秒數
+        /// </summary>
+        [Display("LoadData結束警報秒數")]
+        public int LoadDataFinishAlarmSec { get; set; }
+    }
+
+}

--- a/Controller/ControllerConfig.cs
+++ b/Controller/ControllerConfig.cs
@@ -82,6 +82,9 @@ namespace Controller
                 case nameof(ICSVExceptionService):
                     obj = CSVServiceFactory.Get<ICSVExceptionService>();
                     break;
+                case nameof(ICSVDeviceService):
+                    obj = CSVServiceFactory.Get<ICSVDeviceService>();
+                    break;
 
 
                 case nameof(IDeviceService):

--- a/Controller/Implement/DeviceController.cs
+++ b/Controller/Implement/DeviceController.cs
@@ -31,6 +31,7 @@ namespace Controller.Implement
         IThermostatLogService ThermostatLogService => ControllerConfig.GetService<IThermostatLogService>();
         IRectifierLogService RectifierLogService => ControllerConfig.GetService<IRectifierLogService>();
         IUnLoadService UnLoadService => ControllerConfig.GetService<IUnLoadService>();
+        ILoadDataService LoadDataService = ControllerConfig.GetService<ILoadDataService>();
         IModbus31LogService Modbus31LogService => ControllerConfig.GetService<IModbus31LogService>();
         IModbus32LogService Modbus32LogService => ControllerConfig.GetService<IModbus32LogService>();
         IModbus33LogService Modbus33LogService => ControllerConfig.GetService<IModbus33LogService>();
@@ -43,6 +44,7 @@ namespace Controller.Implement
         ICSVModbus31LogService CSVModbus31LogService => ControllerConfig.GetService<ICSVModbus31LogService>();
         ICSVModbus32LogService CSVModbus32LogService => ControllerConfig.GetService<ICSVModbus32LogService>();
         ICSVModbus33LogService CSVModbus33LogService => ControllerConfig.GetService<ICSVModbus33LogService>();
+        ICSVDeviceService CSVDeviceService => ControllerConfig.GetService<ICSVDeviceService>();
 
         AlarmTypePackage NowAlarmTypePackage;
         bool Enabled = false;
@@ -61,6 +63,12 @@ namespace Controller.Implement
 
         void ImpMonitor(object state)
         {
+            var lastPLCStatus = PLCStatuses.none;
+            var lastPCStatus = PCStatuses.none;
+
+            CSVDeviceService.Log(DeviceLogSourceTypes.PLC, "22008", false, "程式第一次啟動，狀態歸零");
+            CSVDeviceService.Log(DeviceLogSourceTypes.PLC, "22000", false, "程式第一次啟動，狀態歸零");
+
             while (!this.Enabled)
             {
                 try
@@ -76,18 +84,77 @@ namespace Controller.Implement
 
                     if (nowPCSstatus.Result && nowPLCSstatus.Result)
                     {
+                        //22008.08
                         var isUnLoadNotify = (nowPLCSstatus.Value & PLCStatuses.UnLoadNotify) == PLCStatuses.UnLoadNotify;
+                        //22000.08
                         var isReplyUnLoad = (nowPCSstatus.Value & PCStatuses.ReplyUnLoad) == PCStatuses.ReplyUnLoad;
-
+                        //22008.04
                         var isAskLoadData = (nowPLCSstatus.Value & PLCStatuses.AskLoadData) == PLCStatuses.AskLoadData;
+                        //22000.04
                         var isReplyAskLoadData = (nowPCSstatus.Value & PCStatuses.ReplyAskLoadData) == PCStatuses.ReplyAskLoadData;
-
+                        //22008.05
                         var isAutoRuntNotify = (nowPLCSstatus.Value & PLCStatuses.ProduceNotify) == PLCStatuses.ProduceNotify;
+                        //22000.05
                         var isReplyAutoRun = (nowPCSstatus.Value & PCStatuses.ReplyProduce) == PCStatuses.ReplyProduce;
-
-                        //var isBackupMod = false;
+                        //22008.12
                         var isBackupMod = (nowPLCSstatus.Value & PLCStatuses.BackupMod) == PLCStatuses.BackupMod;
+                        //22008.13
                         var isBackupDataReady = (nowPLCSstatus.Value & PLCStatuses.BackupDataReady) == PLCStatuses.BackupDataReady;
+                        //22000.12
+                        var isBackupUnloading = (nowPCSstatus.Value & PCStatuses.BackupUnloading) == PCStatuses.BackupUnloading;
+                        //22000.13
+                        var isBackupUnloadFinish = (nowPCSstatus.Value & PCStatuses.BackupUnloadFinish) == PCStatuses.BackupUnloadFinish;
+
+
+                        //22008.08
+                        var lastisUnLoadNotify = (lastPLCStatus & PLCStatuses.UnLoadNotify) == PLCStatuses.UnLoadNotify;
+                        //22000.08
+                        var lastisReplyUnLoad = (lastPCStatus & PCStatuses.ReplyUnLoad) == PCStatuses.ReplyUnLoad;
+                        //22008.04
+                        var lastisAskLoadData = (lastPLCStatus & PLCStatuses.AskLoadData) == PLCStatuses.AskLoadData;
+                        //22000.04
+                        var lastisReplyAskLoadData = (lastPCStatus & PCStatuses.ReplyAskLoadData) == PCStatuses.ReplyAskLoadData;
+                        //22008.05
+                        var lastisAutoRuntNotify = (lastPLCStatus & PLCStatuses.ProduceNotify) == PLCStatuses.ProduceNotify;
+                        //22000.05
+                        var lastisReplyAutoRun = (lastPCStatus & PCStatuses.ReplyProduce) == PCStatuses.ReplyProduce;
+                        //22008.12
+                        var lastisBackupMod = (lastPLCStatus & PLCStatuses.BackupMod) == PLCStatuses.BackupMod;
+                        //22008.13
+                        var lastisBackupDataReady = (lastPLCStatus & PLCStatuses.BackupDataReady) == PLCStatuses.BackupDataReady;
+                        //22000.12
+                        var lastisBackupUnloading = (lastPCStatus & PCStatuses.BackupUnloading) == PCStatuses.BackupUnloading;
+                        //22000.13
+                        var lastisBackupUnloadFinish = (lastPCStatus & PCStatuses.BackupUnloadFinish) == PCStatuses.BackupUnloadFinish;
+
+
+                        if (isUnLoadNotify != lastisUnLoadNotify)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PLC, "R22008.08", isUnLoadNotify, isUnLoadNotify?"通知下載下料資料":"");
+                        if (isReplyUnLoad != lastisReplyUnLoad)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PC, "R22000.08", isReplyUnLoad, isReplyUnLoad ? "回復完成下載下料資料" : "");
+                        if (isAskLoadData != lastisAskLoadData)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PLC, "R22008.04", isAskLoadData, isAskLoadData?"要求上傳上料資料":"");
+                        if (isReplyAskLoadData != lastisReplyAskLoadData)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PC, "R22000.04", isReplyAskLoadData, isReplyAskLoadData? "回覆完成傳上料資料":"");
+                        if (isAutoRuntNotify != lastisAutoRuntNotify)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PLC, "R22008.05", isAutoRuntNotify, isAutoRuntNotify? "請求清空LoadData" : "");
+                        if (isReplyAutoRun != lastisReplyAutoRun)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PC, "R22000.05", isReplyAutoRun, isReplyAutoRun? "回覆完成清空LoadData" : "");
+                        if (isBackupMod != lastisBackupMod)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PLC, "R22008.12", isBackupMod, isBackupMod ? "通知當前為清線備份模式" : "");
+                        if (isBackupDataReady != lastisBackupDataReady)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PLC, "R22008.13", isBackupDataReady, isBackupDataReady ? "通知下載下料資料備份" : "");
+                        if (isBackupUnloading != lastisBackupUnloading)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PC, "R22000.12", isBackupDataReady, isBackupDataReady ? "通知開始下載備份資料" : "");
+                        if (isBackupUnloadFinish != lastisBackupUnloadFinish)
+                            CSVDeviceService.Log(DeviceLogSourceTypes.PC, "R22000.13", isBackupDataReady, isBackupDataReady ? "通知完成下載備份資料" : "PLC主動清除該記憶點位");
+
+
+                        lastPLCStatus = nowPLCSstatus.Value;
+                        lastPCStatus = nowPCSstatus.Value;
+
+
+
 
                         if (isBackupMod == false && isBackupDataReady == false) AlreadyBackup = false;
 
@@ -117,16 +184,62 @@ namespace Controller.Implement
                             //通知可接收UnloadData, 且PC尚未通知PLC 有接收完成
                             if (isUnLoadNotify && !isReplyUnLoad)
                             {
-                                var r1 = DeviceService.GetUnLoadData(1);
-                                var r2 = DeviceService.GetUnLoadData(2);
-                                if (r1.Result && r2.Result)
+                                var unloadData01ActResult = DeviceService.GetUnLoadData(1);
+                                var unloadData02ActResult = DeviceService.GetUnLoadData(2);
+                                if (unloadData01ActResult.Result && unloadData02ActResult.Result)
                                 {
-                                    UnLoadService.Insert(r1.Value);
-                                    UnLoadService.Insert(r2.Value);
+                                    UnLoadService.Insert(unloadData01ActResult.Value);
+                                    UnLoadService.Insert(unloadData02ActResult.Value);
                                     DeviceService.UpdatePCStatuses(PCStatuses.ReplyUnLoad, true);
 
-                                    var r3 = CSVUnLoadDataService.Log(r1.Value);
-                                    var r4 = CSVUnLoadDataService.Log(r2.Value);
+                                    var r3 = CSVUnLoadDataService.Log(unloadData01ActResult.Value);
+                                    var r4 = CSVUnLoadDataService.Log(unloadData02ActResult.Value);
+
+
+                                    #region 下料LotNo比對 
+                                    var newUnloadLotNo = (unloadData01ActResult.Value.LotNo != LoadController.DummyLotCode) ? unloadData01ActResult.Value.LotNo : unloadData02ActResult.Value.LotNo;
+                                    var lastLotNoResult = UnLoadService.GetLastLotNo();
+                                    if (lastLotNoResult.Result)
+                                    {
+                                        var lastUnloadLotNo = lastLotNoResult.Value;
+                                        if (lastUnloadLotNo != newUnloadLotNo)
+                                        {
+                                            DeviceService.UpdatePCStatuses(PCStatuses.ChangeLotNotify, true);
+                                            //如果前次lotNo == DummyLotCode 不做總數比對判斷
+                                            if (lastUnloadLotNo != LoadController.DummyLotCode)
+                                            {
+                                                var getLoadDataCountResult = LoadDataService.GetLotCount(lastUnloadLotNo);
+                                                var getUnLoadDataCountResult = UnLoadService.GetLotCount(lastUnloadLotNo);
+
+                                                if (getLoadDataCountResult.Result && getUnLoadDataCountResult.Result)
+                                                {
+                                                    var loadDataCount = getLoadDataCountResult.Value;
+                                                    var unLoadDataCount = getUnLoadDataCountResult.Value;
+
+                                                    if (loadDataCount != unLoadDataCount)
+                                                    {
+                                                        DeviceService.UpdatePCStatuses(PCStatuses.DataCountError, true);
+
+                                                        var alarmCode = AlarmTypes_Part02.M719.GetInfo().Code;
+                                                        ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(String.Format("AL501^{0}", lastUnloadLotNo)));
+                                                        CSVAlarmLogService.HappenLog(alarmCode);
+                                                        CSVAlarmLogService.DisMissLog(alarmCode);
+                                                    }
+                                                }//判斷取得該LotNo LoadData及UnLoadData 數量是否成功
+                                                else
+                                                {
+                                                }
+                                            }
+                                        }//判斷本次LotNo 是否與前次LotNo 是否不一致
+                                    }//判斷取得lastunloadlotNo是否成功判斷
+                                    else
+                                    {
+                                    }
+                                    #endregion
+
+                                }
+                                else
+                                {
                                 }
                             }
                             //通知可接收UnloadData, 且PC尚未通知PLC 有接收完成
@@ -170,7 +283,7 @@ namespace Controller.Implement
                                         else
                                         {
                                             var lotcode = LoadController.DummyLotCode;
-                                            var recipecode = LoadController.DummyLotCode;
+                                            var recipecode = "Dummy";
                                             ThreadPool.QueueUserWorkItem(p => MESController.SendATC(lotcode, recipecode));
                                         }
 
@@ -190,14 +303,13 @@ namespace Controller.Implement
                                     AlreadyMoveInLoadData = null;
                                 }
 
-                                //通知可接收UnloadData, 且PC尚未通知PLC 有接收完成
+                                //通知可清除LoadData, 且PC尚未通知PLC 有接收完成
                                 if (isAutoRuntNotify && !isReplyAutoRun)
                                 {
                                     var r1 = DeviceService.ReSetLoadData();
                                     if (r1.Result)
                                         DeviceService.UpdatePCStatuses(PCStatuses.ReplyProduce, true);
                                 }
-                                //通知可接收UnloadData, 且PC尚未通知PLC 有接收完成
                                 else if (!isAutoRuntNotify && isReplyAutoRun)
                                     DeviceService.UpdatePCStatuses(PCStatuses.ReplyProduce, false);
                             }
@@ -237,28 +349,28 @@ namespace Controller.Implement
                         var nowAlarmPart08 = r11.Value.Part08;
 
                         var newPart01 = (NowAlarmTypePackage.Part01 & nowAlarmPart01) ^ nowAlarmPart01;
-                        var mesPart01 = (nowAlarmPart01 ^ newPart01) ^ NowAlarmTypePackage.Part01;
+                        var nowPart01 = (nowAlarmPart01 ^ newPart01) ^ NowAlarmTypePackage.Part01;
 
                         var newPart02 = (NowAlarmTypePackage.Part02 & nowAlarmPart02) ^ nowAlarmPart02;
-                        var mesPart02 = (nowAlarmPart02 ^ newPart02) ^ NowAlarmTypePackage.Part02;
+                        var nowPart02 = (nowAlarmPart02 ^ newPart02) ^ NowAlarmTypePackage.Part02;
 
                         var newPart03 = (NowAlarmTypePackage.Part03 & nowAlarmPart03) ^ nowAlarmPart03;
-                        var mesPart03 = (nowAlarmPart03 ^ newPart03) ^ NowAlarmTypePackage.Part03;
+                        var nowPart03 = (nowAlarmPart03 ^ newPart03) ^ NowAlarmTypePackage.Part03;
 
                         var newPart04 = (NowAlarmTypePackage.Part04 & nowAlarmPart04) ^ nowAlarmPart04;
-                        var mesPart04 = (nowAlarmPart04 ^ newPart04) ^ NowAlarmTypePackage.Part04;
+                        var nowPart04 = (nowAlarmPart04 ^ newPart04) ^ NowAlarmTypePackage.Part04;
 
                         var newPart05 = (NowAlarmTypePackage.Part05 & nowAlarmPart05) ^ nowAlarmPart05;
-                        var mesPart05 = (nowAlarmPart05 ^ newPart05) ^ NowAlarmTypePackage.Part05;
+                        var nowPart05 = (nowAlarmPart05 ^ newPart05) ^ NowAlarmTypePackage.Part05;
 
                         var newPart06 = (NowAlarmTypePackage.Part06 & nowAlarmPart06) ^ nowAlarmPart06;
-                        var mesPart06 = (nowAlarmPart06 ^ newPart06) ^ NowAlarmTypePackage.Part06;
+                        var nowPart06 = (nowAlarmPart06 ^ newPart06) ^ NowAlarmTypePackage.Part06;
 
                         var newPart07 = (NowAlarmTypePackage.Part07 & nowAlarmPart07) ^ nowAlarmPart07;
-                        var mesPart07 = (nowAlarmPart07 ^ newPart07) ^ NowAlarmTypePackage.Part07;
+                        var nowPart07 = (nowAlarmPart07 ^ newPart07) ^ NowAlarmTypePackage.Part07;
 
                         var newPart08 = (NowAlarmTypePackage.Part08 & nowAlarmPart08) ^ nowAlarmPart08;
-                        var mesPart08 = (nowAlarmPart08 ^ newPart08) ^ NowAlarmTypePackage.Part08;
+                        var nowPart08 = (nowAlarmPart08 ^ newPart08) ^ NowAlarmTypePackage.Part08;
 
                         if (NowAlarmTypePackage.Part01 != nowAlarmPart01)
                         {
@@ -272,7 +384,7 @@ namespace Controller.Implement
                                     MESService.SendAlarmNotify(value.GetInfo().Code);
                                     CSVAlarmLogService.HappenLog(value.GetInfo().Code);
                                 }
-                                if ((mesPart01 & value) == value)
+                                if ((nowPart01 & value) == value)
                                 {
                                     AlarmLogService.Finish(value);
                                     CSVAlarmLogService.DisMissLog(value.GetInfo().Code);
@@ -292,7 +404,7 @@ namespace Controller.Implement
                                     ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(value.GetInfo().Code)); ;
                                     CSVAlarmLogService.HappenLog(value.GetInfo().Code);
                                 }
-                                if ((mesPart02 & value) == value)
+                                if ((nowPart02 & value) == value)
                                 {
                                     AlarmLogService.Finish(value);
                                     CSVAlarmLogService.DisMissLog(value.GetInfo().Code);
@@ -312,7 +424,7 @@ namespace Controller.Implement
                                     ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(value.GetInfo().Code));
                                     CSVAlarmLogService.HappenLog(value.GetInfo().Code);
                                 }
-                                if ((mesPart03 & value) == value)
+                                if ((nowPart03 & value) == value)
                                 {
                                     AlarmLogService.Finish(value);
                                     CSVAlarmLogService.DisMissLog(value.GetInfo().Code);
@@ -331,7 +443,7 @@ namespace Controller.Implement
                                     ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(value.GetInfo().Code));
                                     CSVAlarmLogService.HappenLog(value.GetInfo().Code);
                                 }
-                                if ((mesPart04 & value) == value)
+                                if ((nowPart04 & value) == value)
                                 {
                                     AlarmLogService.Finish(value);
                                     CSVAlarmLogService.DisMissLog(value.GetInfo().Code);
@@ -350,7 +462,7 @@ namespace Controller.Implement
                                     ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(value.GetInfo().Code));
                                     CSVAlarmLogService.HappenLog(value.GetInfo().Code);
                                 }
-                                if ((mesPart05 & value) == value)
+                                if ((nowPart05 & value) == value)
                                 {
                                     AlarmLogService.Finish(value);
                                     CSVAlarmLogService.DisMissLog(value.GetInfo().Code);
@@ -369,7 +481,7 @@ namespace Controller.Implement
                                     ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(value.GetInfo().Code));
                                     CSVAlarmLogService.HappenLog(value.GetInfo().Code);
                                 }
-                                if ((mesPart06 & value) == value)
+                                if ((nowPart06 & value) == value)
                                 {
                                     AlarmLogService.Finish(value);
                                     CSVAlarmLogService.DisMissLog(value.GetInfo().Code);
@@ -389,7 +501,7 @@ namespace Controller.Implement
                                     ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(value.GetInfo().Code));
                                     CSVAlarmLogService.HappenLog(value.GetInfo().Code);
                                 }
-                                if ((mesPart07 & value) == value)
+                                if ((nowPart07 & value) == value)
                                 {
                                     AlarmLogService.Finish(value);
                                     CSVAlarmLogService.DisMissLog(value.GetInfo().Code);
@@ -408,7 +520,7 @@ namespace Controller.Implement
                                     ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(value.GetInfo().Code));
                                     CSVAlarmLogService.HappenLog(value.GetInfo().Code);
                                 }
-                                if ((mesPart08 & value) == value)
+                                if ((nowPart08 & value) == value)
                                 {
                                     AlarmLogService.Finish(value);
                                     CSVAlarmLogService.DisMissLog(value.GetInfo().Code);

--- a/Controller/Implement/LoadController.cs
+++ b/Controller/Implement/LoadController.cs
@@ -192,6 +192,7 @@ namespace Controller.Implement
                             var msg = msgs[1] + msgs[2];
                             return new ActResult<List<LoadDataDTO>>(new Exception(msg));
                         }
+                        //return new ActResult<List<LoadDataDTO>>(new Exception("請重新MoveIn."));
                     }
                     else
                     {
@@ -259,6 +260,9 @@ namespace Controller.Implement
                 {
                     return new ActResult<List<LoadDataDTO>>(new Exception("MES與資料庫皆無此Recipe紀錄 拒絕操作"));
                 }
+
+
+
 
                 //尾掛Recipe相關
                 var shelfQuantity = Quantity_ % 4;

--- a/Controller/Implement/LoadController.cs
+++ b/Controller/Implement/LoadController.cs
@@ -149,7 +149,7 @@ namespace Controller.Implement
                         case ExceptionTypes.WrongUserID:
                             return new ActResult<List<LoadDataDTO>>(new Exception(String.Format("從MES取得Recipe失敗，錯誤訊息:無此無塵衣號碼紀錄")));
                         case ExceptionTypes.ErrorMsg:
-                            return new ActResult<List<LoadDataDTO>>(new Exception(String.Format("從MES取得Recipe失敗，錯誤訊息:{0}", r1.Exception.Message)));
+                            return new ActResult<List<LoadDataDTO>>(new Exception(String.Format("從MES取得Recipe失敗，錯誤訊息:[Type4]{0}", r1.Remarks)));
                         default:
                             return new ActResult<List<LoadDataDTO>>(new Exception(String.Format("從MES取得Recipe失敗，錯誤訊息:{0}", r1.Exception.Message)));
                     }

--- a/Controller/Implement/LoadController.cs
+++ b/Controller/Implement/LoadController.cs
@@ -148,6 +148,8 @@ namespace Controller.Implement
                             return new ActResult<List<LoadDataDTO>>(new Exception(String.Format("從MES取得Recipe失敗，錯誤訊息:此批未上機")));
                         case ExceptionTypes.WrongUserID:
                             return new ActResult<List<LoadDataDTO>>(new Exception(String.Format("從MES取得Recipe失敗，錯誤訊息:無此無塵衣號碼紀錄")));
+                        case ExceptionTypes.ErrorMsg:
+                            return new ActResult<List<LoadDataDTO>>(new Exception(String.Format("從MES取得Recipe失敗，錯誤訊息:{0}", r1.Exception.Message)));
                         default:
                             return new ActResult<List<LoadDataDTO>>(new Exception(String.Format("從MES取得Recipe失敗，錯誤訊息:{0}", r1.Exception.Message)));
                     }

--- a/Controller/Implement/SettingController.cs
+++ b/Controller/Implement/SettingController.cs
@@ -124,6 +124,11 @@ namespace Controller.Implement
                 {
                     var r1 = IniHelper.SetValue(nameof(ADCConfig), String.Format("#{0}\r\n{1}", info.GetCustomAttribute<DisplayAttribute>().ZHTW, info.Name), info.GetValue(DefaultConfig.ADCConfig).ToString(), IniFilePath_);
                 }
+
+                foreach (var info in typeof(LoadDataConfig).GetProperties())
+                {
+                    var r1 = IniHelper.SetValue(nameof(LoadDataConfig), String.Format("#{0}\r\n{1}", info.GetCustomAttribute<DisplayAttribute>().ZHTW, info.Name), info.GetValue(DefaultConfig.LoadDataConfig).ToString(), IniFilePath_);
+                }
             }
         }
 
@@ -188,7 +193,7 @@ namespace Controller.Implement
                 var newitem = new ConvertConfig();
                 foreach (var info in typeof(ConvertConfig).GetProperties())
                 {
-                    var value = IniHelper.GetValue<double>(nameof(ConvertConfig), info.Name, (double)info.GetValue(DefaultConfig.ConvertConfig),  IniPath_).Value;
+                    var value = IniHelper.GetValue<double>(nameof(ConvertConfig), info.Name, (double)info.GetValue(DefaultConfig.ConvertConfig), IniPath_).Value;
                     info.SetValue(newitem, value);
                 }
                 return new ActResult<ConvertConfig>(newitem);
@@ -214,6 +219,24 @@ namespace Controller.Implement
             catch (Exception Ex)
             {
                 return new ActResult<ADCConfig>(Ex);
+            }
+        }
+
+        public ActResult<LoadDataConfig> GetLoadDataConfigValue(string IniPath_)
+        {
+            try
+            {
+                var newitem = new LoadDataConfig();
+                foreach (var info in typeof(LoadDataConfig).GetProperties())
+                {
+                    var value = IniHelper.GetValue<int>(nameof(LoadDataConfig), info.Name, (int)info.GetValue(DefaultConfig.LoadDataConfig), IniPath_).Value;
+                    info.SetValue(newitem, value);
+                }
+                return new ActResult<LoadDataConfig>(newitem);
+            }
+            catch (Exception Ex)
+            {
+                return new ActResult<LoadDataConfig>(Ex);
             }
         }
 

--- a/Controller/Interface/IDeviceController.cs
+++ b/Controller/Interface/IDeviceController.cs
@@ -1,5 +1,6 @@
 ﻿using Common;
 using Common.DTO;
+using Common.ExConfig;
 using Common.Interface;
 
 namespace Controller.Interface
@@ -8,6 +9,10 @@ namespace Controller.Interface
     {
         bool IsConnectPLC1 { get; }
         bool IsConnectPLC2 { get; }
+
+        LoadDataConfig NowLoadDataConfig { get; }
+
+        ActResult SetLoadDataConfig(LoadDataConfig LoadDataConfig_);
 
         ActResult<Modbus31LogDTO> GetNowModbus31Log();
 

--- a/Controller/Interface/ISettingController.cs
+++ b/Controller/Interface/ISettingController.cs
@@ -43,5 +43,7 @@ namespace Controller.Interface
         ActResult<ConvertConfig> GetConvertConfigValue(string IniPath_);
 
         ActResult<ADCConfig> GetADCConfigValue(string IniPath_);
+
+        ActResult<LoadDataConfig> GetLoadDataConfigValue(string IniPath_);
     }
 }

--- a/Service.CSV/CSVServiceFactory.cs
+++ b/Service.CSV/CSVServiceFactory.cs
@@ -42,6 +42,9 @@ namespace Service.CSV
                 case nameof(ICSVExceptionService):
                     obj = new CSVExceptionService();
                     break;
+                case nameof(ICSVDeviceService):
+                    obj = new CSVDeviceService();
+                    break;
                 default:
                     throw new Exception(String.Format("Not Support {0}.", typeof(T).Name));
             }

--- a/Service.CSV/Enum/DeviceLogSourceTypes.cs
+++ b/Service.CSV/Enum/DeviceLogSourceTypes.cs
@@ -1,0 +1,9 @@
+﻿namespace Service.CSV
+{
+    public enum DeviceLogSourceTypes
+    {
+        PLC,
+        PC
+    }
+
+}

--- a/Service.CSV/Implement/CSVDeviceService.cs
+++ b/Service.CSV/Implement/CSVDeviceService.cs
@@ -5,14 +5,17 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
+
 namespace Service.CSV.Implement
 {
-    internal class CSVAlarmLogService : ICSVAlarmLogService
+    internal class CSVDeviceService : ICSVDeviceService
     {
-        readonly string FolderPath = String.Format(@"D:\CSVlog\Alarm\", System.Environment.CurrentDirectory);
+        readonly string FolderPath = CSVServiceFactory.BasicFolderPath + @"DeviceLog\";
 
         static readonly object Token = new object();
-        public ActResult DisMissLog(int EnumValue)
+
+
+        public ActResult Log(DeviceLogSourceTypes DeviceLogSourceType_, string MemoryAddress_, bool Value_, string Remarks_ = "")
         {
             lock (Token)
             {
@@ -23,16 +26,16 @@ namespace Service.CSV.Implement
                     DateTime nowDateTime = DateTime.Now;
                     var forlderPath = String.Format(@"{0}{1:0000}{2:00}", FolderPath, nowDateTime.Year, nowDateTime.Month, nowDateTime.Day);
                     string fileName = String.Format(@"{0}\{1:0000}{2:00}{3:00}Log.csv", forlderPath, nowDateTime.Year, nowDateTime.Month, nowDateTime.Day);
+
                     if (!Directory.Exists(forlderPath)) Directory.CreateDirectory(forlderPath);
 
                     if (!File.Exists(fileName))
                     {
-                        File.Create(fileName);
-                        data.Add(String.Format("Type,發生時間,AlarmCode"));
+                        string column = String.Format("{0},{1},{2},{3},{4}","DateTime", "Source", "MemoryAddress", "Value", "Remarks");
+                        data.Add(column);
                     }
-
-
-                    data.Add(String.Format("解除,{0},{1}", nowDateTime.GetString(), EnumValue));
+                    var value = Value_ ? "ON" : "OFF";
+                    data.Add(String.Format("{0},{1,3},{2,3},{3},{4}",DateTime.Now.GetString(), DeviceLogSourceType_.ToString(), MemoryAddress_, value, Remarks_));
 
                     CSVServiceFactory.WriteFile(fileName, data);
 
@@ -45,7 +48,7 @@ namespace Service.CSV.Implement
             }
         }
 
-        public ActResult HappenLog(int EnumValue)
+        public ActResult CatchLog(string Msg_)
         {
             lock (Token)
             {
@@ -55,21 +58,20 @@ namespace Service.CSV.Implement
 
                     DateTime nowDateTime = DateTime.Now;
                     var forlderPath = String.Format(@"{0}{1:0000}{2:00}", FolderPath, nowDateTime.Year, nowDateTime.Month, nowDateTime.Day);
-                    string fileName = String.Format(@"{0}\{1:0000}{2:00}{3:00}Log.csv", forlderPath, nowDateTime.Year, nowDateTime.Month, nowDateTime.Day);
+                    string fileName = String.Format(@"{0}\{1:0000}{2:00}{3:00}catchLog.csv", forlderPath, nowDateTime.Year, nowDateTime.Month, nowDateTime.Day);
+
                     if (!Directory.Exists(forlderPath)) Directory.CreateDirectory(forlderPath);
 
                     if (!File.Exists(fileName))
                     {
-                        File.Create(fileName);
-                        data.Add(String.Format("Type,發生時間,AlarmCode"));
+                        string column = String.Format("{0},{1}", "DateTime", "Msg");
+                        data.Add(column);
                     }
-
-                    data.Add(String.Format("發生,{0},{1}", nowDateTime.GetString(), EnumValue));
+                    data.Add(String.Format("{0},{1}", DateTime.Now.GetString(), Msg_));
 
                     CSVServiceFactory.WriteFile(fileName, data);
 
                     return new ActResult(true);
-
                 }
                 catch (Exception Ex)
                 {
@@ -77,5 +79,7 @@ namespace Service.CSV.Implement
                 }
             }
         }
+
     }
+
 }

--- a/Service.CSV/Interface/ICSVAlarmLogService.cs
+++ b/Service.CSV/Interface/ICSVAlarmLogService.cs
@@ -24,6 +24,11 @@ namespace Service.CSV.Interface
     {
         ActResult Log(LoadDataDTO LoadData_);
     }
+    public interface ICSVDeviceService : IService
+    {
+        ActResult Log(DeviceLogSourceTypes DeviceLogSourceType_, string MemoryAddress_, bool Value_, string Remarks_ = "");
+        ActResult CatchLog(string Msg_);
+    }
 
     public interface ICSVUnLoadDataService : IService
     {

--- a/Service.CSV/Service.CSV.csproj
+++ b/Service.CSV/Service.CSV.csproj
@@ -63,7 +63,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Enum\DeviceLogSourceTypes.cs" />
     <Compile Include="Implement\CSVAlarmLogService.cs" />
+    <Compile Include="Implement\CSVDeviceService.cs" />
     <Compile Include="Implement\CSVExceptionService.cs" />
     <Compile Include="Implement\CSVLoadDataService.cs" />
     <Compile Include="Implement\CSVModbus31LogService.cs" />

--- a/Service.DataBase/Implement/LoadDataService.cs
+++ b/Service.DataBase/Implement/LoadDataService.cs
@@ -55,6 +55,25 @@ namespace Service.DataBase.Implement
             }
         }
 
+
+        public ActResult<int> GetLotCount(string LotCode_)
+        {
+            try
+            {
+                using (var unitwork = ServiceConfig.GetUnitWork())
+                {
+                    var firstcount = unitwork.Repository<LoadData>().Reads(p => p.First_LotCode == LotCode_ && p.IsNormalFinish == true).Count();
+                    var secondcount = unitwork.Repository<LoadData>().Reads(p => p.Second_LotCode == LotCode_ && p.IsNormalFinish == true).Count();
+                    var totalcount = firstcount + secondcount;
+                    return new ActResult<int>(totalcount);
+                }
+            }
+            catch (Exception Ex)
+            {
+                return new ActResult<int>(Ex);
+            }
+        }
+
         public ActResult<List<LoadDataDTO>> Gets(long StartTimeTicks_, long EndTimeTicks_, long Limit_)
         {
             var sqlstr = "SELECT * FROM loaddatas AS `LD` WHERE ";
@@ -175,7 +194,7 @@ namespace Service.DataBase.Implement
                     {
                         entity.SortTimeTicks = sortTimeTicks += 50;
                         entity.EditorID = EditorID_;
-                        entity.SystemLog += String.Format("Edit SortTimeTicks At {0} By {1}", DateTime.Now.Ticks, EditorID_);
+                        entity.SystemLog += String.Format(",PlugIn LoadData Edit SortTimeTicks At {0} By {1}", DateTime.Now.GetString(), EditorID_);
                         unitwork.Repository<LoadData>().Update(entity);
                     }
                     unitwork.Save();
@@ -202,11 +221,11 @@ namespace Service.DataBase.Implement
                     var newEntity = DTO_.ToEntity();
                     newEntity.GetNewIDAndTimeTick();
                     newEntity.SortTimeTicks = entity.SortTimeTicks;
-                    newEntity.SystemLog += String.Format("Create At {0}, ReplaceID:{1} By :{2}", DateTime.Now.GetString(), entity.ID, EditorID_);
+                    newEntity.SystemLog += String.Format(",Edit Create At {0}, ReplaceID:{1} :{2}", DateTime.Now.GetString(), entity.ID, EditorID_);
                     
                     entity.FinishTimeTicks = DateTime.Now.Ticks;
                     entity.IsNormalFinish = false;
-                    entity.SystemLog += String.Format("Edit At {0}, NewLoadData's ID:{1} By :{2}", DateTime.Now.GetString(), newEntity.ID, EditorID_);
+                    entity.SystemLog += String.Format(",Edit At {0}, NewLoadData's ID:{1} By :{2}", DateTime.Now.GetString(), newEntity.ID, EditorID_);
                     entity.Enabled = false;
 
                     unitwork.Repository<LoadData>().Update(entity);
@@ -236,7 +255,7 @@ namespace Service.DataBase.Implement
                     entity.IsNormalFinish = true;
                     entity.Enabled = false;
 
-                    entity.SystemLog += String.Format("Finish At {0}", DateTime.Now.Ticks);
+                    entity.SystemLog += String.Format(",Finish At {0}", DateTime.Now.GetString());
                     unitwork.Repository<LoadData>().Update(entity);
                     unitwork.Save();
 
@@ -262,7 +281,7 @@ namespace Service.DataBase.Implement
                     entity.IsNormalFinish = false;
                     entity.Enabled = false;
 
-                    entity.SystemLog += String.Format("ReMove At {0} By {1}", DateTime.Now.GetString(), EditorID_);
+                    entity.SystemLog += String.Format(",ReMove At {0} By {1}", DateTime.Now.GetString(), EditorID_);
                     unitwork.Repository<LoadData>().Update(entity);
                     unitwork.Save();
 

--- a/Service.DataBase/Implement/UnLoadService.cs
+++ b/Service.DataBase/Implement/UnLoadService.cs
@@ -62,6 +62,54 @@ namespace Service.DataBase.Implement
                 }
             }
         }
+
+        public ActResult<int> GetLotCount(string LotCode_)
+        {
+            using (var unitOfWork = ServiceConfig.GetUnitWork())
+            {
+                try
+                {
+                    var count = unitOfWork.Repository<UnLoadDataLog>().Reads(p => p.LotNo == LotCode_).Count();
+                    return new ActResult<int>(count);
+                }
+                catch (Exception Ex)
+                {
+                    return new ActResult<int>(Ex);
+                }
+            }
+        }
+
+        public ActResult<string> GetLastLotNo()
+        {
+            var sqlstr = String.Format(
+                  @"
+                    SELECT `Log`.`{2}`
+                    FROM `{0}` AS `Log`  
+                    ORDER BY `Log`.`{1}` DESC 
+                    LIMIT 1
+                ",
+                  nameof(UnLoadDataLog),
+                  nameof(UnLoadDataLog.Rowid),
+                  nameof(UnLoadDataLog.LotNo)
+              );
+
+            using (var unitOfWork = ServiceConfig.GetUnitWork())
+            {
+                try
+                {
+                    var lotNo = unitOfWork.Repository<UnLoadDataLog>().Reads().OrderByDescending(p => p.Rowid).First().LotNo;
+                    return new ActResult<string>(lotNo);
+                    //var lotNos = unitOfWork.UseDapper<string>(sqlstr, null).ToList();
+                    //return new ActResult<string>(lotNos.First());
+                }
+                catch (Exception Ex)
+                {
+                    return new ActResult<string>(Ex);
+                }
+            }
+        }
+
+
         public ActResult<List<UnLoadDataLogDTO>> Gets(long StartTimeTicks_, long EndTimeTicks_, long Limit_)
         {
 

--- a/Service.DataBase/Interface/ILoadDataService.cs
+++ b/Service.DataBase/Interface/ILoadDataService.cs
@@ -9,6 +9,8 @@ namespace Service.DataBase.Interface
     {
         ActResult<LoadDataDTO> Get(string LoadDataID_);
 
+        ActResult<int> GetLotCount(string LotCode_);
+
         ActResult<LoadDataDTO> Edit(LoadDataDTO DTO_, string EditorID_);
 
         ActResult Finish(string ID_);

--- a/Service.DataBase/Interface/IUnLoadService.cs
+++ b/Service.DataBase/Interface/IUnLoadService.cs
@@ -7,6 +7,8 @@ namespace Service.DataBase.Interface
 {
     public interface IUnLoadService : IService
     {
+        ActResult<int> GetLotCount(string LotCode_);
+        ActResult<string> GetLastLotNo();
         ActResult<List<UnLoadDataLogDTO>> Gets(long StartTimeTicks_, long EndTimeTicks_, long Limit_);
         ActResult<List<UnLoadDataLogDTO>> Gets(string LotNo_, long Limit_);
         ActResult Insert(UnLoadDataLogDTO value);

--- a/Service.Device/Enums/PCStatuses.cs
+++ b/Service.Device/Enums/PCStatuses.cs
@@ -24,7 +24,7 @@ namespace Service.Device.Enums
         Empty011            = 0x0800,
         BackupUnloading     = 0x1000,
         BackupUnloadFinish  = 0x2000,
-        Empty014            = 0x4000,
-        Empty015            = 0x8000,
+        ChangeLotNotify     = 0x4000,
+        DataCountError      = 0x8000,
     }
 }

--- a/Service.Device/Enums/PCStatuses.cs
+++ b/Service.Device/Enums/PCStatuses.cs
@@ -10,21 +10,21 @@ namespace Service.Device.Enums
     public enum PCStatuses : UInt16
     {
         none                = 0x0000,
-        Empty000            = 0x0001,
-        Empty001            = 0x0002,
-        Empty002            = 0x0004,
-        Empty003            = 0x0008,
-        ReplyAskLoadData    = 0x0010,
-        ReplyProduce        = 0x0020,
-        Empty006            = 0x0040,
-        Empty007            = 0x0080,
-        ReplyUnLoad         = 0x0100,
-        Empty009            = 0x0200,
-        Empty010            = 0x0400,
-        Empty011            = 0x0800,
-        BackupUnloading     = 0x1000,
-        BackupUnloadFinish  = 0x2000,
-        ChangeLotNotify     = 0x4000,
-        DataCountError      = 0x8000,
+        Empty000            = 0x0001,//0
+        Empty001            = 0x0002,//1
+        Empty002            = 0x0004,//2
+        Empty003            = 0x0008,//3
+        ReplyAskLoadData    = 0x0010,//4
+        ReplyProduce        = 0x0020,//5
+        Empty006            = 0x0040,//6
+        Empty007            = 0x0080,//7
+        ReplyUnLoad         = 0x0100,//8
+        Empty009            = 0x0200,//9
+        Empty010            = 0x0400,//A
+        LoadDataTimeAlarm   = 0x0800,//B
+        BackupUnloading     = 0x1000,//C
+        BackupUnloadFinish  = 0x2000,//D
+        ChangeLotNotify     = 0x4000,//E
+        DataCountError      = 0x8000,//F
     }
 }

--- a/Service.Device/Service.Device.csproj
+++ b/Service.Device/Service.Device.csproj
@@ -69,7 +69,7 @@
   <ItemGroup>
     <Reference Include="ConnectorLibrary, Version=1.0.4.2, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\ToolSupport\ConnectorLibrary\ConnectorLibrary\ConnectorLibrary\bin\x86\Debug\ConnectorLibrary.dll</HintPath>
+      <HintPath>..\..\ConnectorLibrary\ConnectorLibrary\bin\x86\Debug\ConnectorLibrary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Service.Device/Service.Device.csproj
+++ b/Service.Device/Service.Device.csproj
@@ -67,9 +67,8 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ConnectorLibrary, Version=1.0.4.2, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\ConnectorLibrary\ConnectorLibrary\bin\x86\Debug\ConnectorLibrary.dll</HintPath>
+    <Reference Include="ConnectorLibrary">
+      <HintPath>..\..\..\..\ToolSupport\ConnectorLibrary\ConnectorLibrary\ConnectorLibrary\bin\x86\Debug\ConnectorLibrary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Service.MES/Implement/MESService.cs
+++ b/Service.MES/Implement/MESService.cs
@@ -262,7 +262,14 @@ namespace Service.MES.Implement
 
                     long startTick = DateTime.Now.Ticks;
 
-                    while (!(this.RMS_ACK_Available || this.OnReceiveException || this.RMS_ERRORType1_Available || this.RMS_ERRORType2_Available || this.RMS_ERRORType3_Available))
+                    while (!(
+                        this.RMS_ACK_Available || 
+                        this.OnReceiveException || 
+                        this.RMS_ERRORType1_Available || 
+                        this.RMS_ERRORType2_Available || 
+                        this.RMS_ERRORType3_Available ||
+                        this.RMS_ERRORType4_Available
+                    ))
                     {
                         Thread.Sleep(200);
                         if (DateTime.Now.Ticks > startTick + TimeOut * 10000000)

--- a/Service.MES/Implement/MESService.cs
+++ b/Service.MES/Implement/MESService.cs
@@ -43,6 +43,10 @@ namespace Service.MES.Implement
         private string RMS_ERRORType3_Data { get; set; }
 
 
+        private bool RMS_ERRORType4_Available { get; set; }
+        private string RMS_ERRORType4_Data { get; set; }
+
+
         private bool END_SHELF_ACK_Data_Available { get; set; }
         private string END_SHELF_ACK_Data { get; set; }
 
@@ -175,6 +179,10 @@ namespace Service.MES.Implement
                                     RMS_ERRORType3_Data = FailReson;
                                     RMS_ERRORType3_Available = true;
                                     break;
+                                case "Type4":
+                                    RMS_ERRORType4_Data = FailReson;
+                                    RMS_ERRORType4_Available = true;
+                                    break;
                             }
                         }
                         else if (e.Data[0].Split('^')[1].ToUpper() == nameof(CmdType.END_SHELF_ERROR))
@@ -237,11 +245,13 @@ namespace Service.MES.Implement
                     this.RMS_ERRORType1_Data = String.Empty;
                     this.RMS_ERRORType2_Data = String.Empty;
                     this.RMS_ERRORType3_Data = String.Empty;
+                    this.RMS_ERRORType4_Data = String.Empty;
                     this.RMS_ACK_Data = String.Empty;
                     this.ReceiveException = null;
                     RMS_ERRORType1_Available = false;
                     RMS_ERRORType2_Available = false;
                     RMS_ERRORType3_Available = false;
+                    RMS_ERRORType4_Available = false;
                     RMS_ACK_Available = false;
                     OnReceiveException = false;
 
@@ -291,6 +301,17 @@ namespace Service.MES.Implement
                         LogHelper.Log(String.Format("[Get][GetMESObject]:{0}", "RMS_ERRORType3"));
                         return new ActResult<AE2TalkObjectV2>(ExceptionTypes.WrongUserID, data);
                     }
+                    else if (this.RMS_ERRORType4_Available)
+                    {
+                        RMS_ERRORType4_Available = false;
+
+                        string data = String.Empty;
+                        data += this.RMS_ERRORType4_Data;
+                        this.RMS_ERRORType4_Data = String.Empty;
+                        LogHelper.Log(String.Format("[Get][GetMESObject]:{0}", "RMS_ERRORType4"));
+                        return new ActResult<AE2TalkObjectV2>(ExceptionTypes.ErrorMsg, data, data);
+                    }
+
                     else if (this.RMS_ACK_Available)
                     {
                         RMS_ACK_Available = false;

--- a/TestConsoleApp/Program.cs
+++ b/TestConsoleApp/Program.cs
@@ -37,6 +37,9 @@ namespace TestConsoleApp
                 Thread.Sleep(100);
             }
 
+            //deviceService.UpdatePCStatuses(Service.Device.Enums.PCStatuses.LoadDataTimeAlarm, true);
+            //return;
+
             deviceService.UpdatePCStatuses(Service.Device.Enums.PCStatuses.DataCountError, true);
             return;
 

--- a/TestConsoleApp/Program.cs
+++ b/TestConsoleApp/Program.cs
@@ -20,7 +20,7 @@ using Controller;
 using Service.MES.ExObject;
 using Newtonsoft.Json;
 using Common;
-using Service.Device;
+using Service.MES;
 
 namespace TestConsoleApp
 {
@@ -29,94 +29,21 @@ namespace TestConsoleApp
 
         static void Main(string[] args)
         {
-            var deviceService = DeviceServiceFactory.Get(false);
+            var service = MESServiceFactory.Get();
 
-            while (!deviceService.IsConnect_PLC1)
+            service.StartListen(7079);
+
+            while (!service.IsConnect)
             {
-
-                Thread.Sleep(100);
+                Thread.Sleep(1000);
             }
-
-            //deviceService.UpdatePCStatuses(Service.Device.Enums.PCStatuses.LoadDataTimeAlarm, true);
-            //return;
-
-            deviceService.UpdatePCStatuses(Service.Device.Enums.PCStatuses.DataCountError, true);
-            return;
-
-
-            var CSVservice = CSVServiceFactory.Get<ICSVDeviceService>();
-            CSVservice.Log(DeviceLogSourceTypes.PC, "22000.1", true);
-            CSVservice.Log(DeviceLogSourceTypes.PLC, "22008.1", false, "TestRemarks");
-
-            return;
-
-            var LoadDataService = Service.DataBase.DBServiceFactory.Get<ILoadDataService>();
-            var UnLoadService = Service.DataBase.DBServiceFactory.Get<IUnLoadService>();
-            UnLoadService.GetLastLotNo();
-            //var getlastLotNoResult = unLoadService.GetLastLotNo();
-            //var getUnloadtLotCountResult = loadDataService.GetLotCount("L221028012");
-            //var getloadLotCountResult = unLoadService.GetLotCount("L221028012");
-
-
-            //Console.WriteLine(String.Format("LastLotNo:{0}", getlastLotNoResult.Value));
-            //var lastLotNo = "L221028012";
-            //Console.WriteLine(String.Format("{0} 's LoadData Count :{1}", lastLotNo, getloadLotCountResult.Value));
-            //Console.WriteLine(String.Format("{0} 's UnLoadData Count :{1}", lastLotNo, getUnloadtLotCountResult.Value));
-
-
-            var r1 = new ActResult<UnLoadDataLogDTO>(new UnLoadDataLogDTO() { LotNo = "AAA" });
-            var r2 = new ActResult<UnLoadDataLogDTO>(new UnLoadDataLogDTO() { LotNo = "AAA" });
-
-            #region 下料LotNo比對 
-            var newUnloadLotNo = (r1.Value.LotNo != "DummyLotCode") ? r1.Value.LotNo : r2.Value.LotNo;
-            var lastLotNoResult = UnLoadService.GetLastLotNo();
-            if (lastLotNoResult.Result)
+            var a = "";
+            while (true)
             {
-                //var lastUnloadLotNo = lastLotNoResult.Value;
-                //var lastUnloadLotNo = "DummyLotCode";
-                //var lastUnloadLotNo = "L221028012";
-                var lastUnloadLotNo = "L220926064";
-                if (lastUnloadLotNo != newUnloadLotNo)
-                {
-                    //DeviceService.UpdatePCStatuses(PCStatuses.ChangeLotNotify, true);
-                    //如果前次lotNo == DummyLotCode 不做總數比對判斷
-                    if (lastUnloadLotNo != "DummyLotCode")
-                    {
-                        var getLoadDataCountResult = LoadDataService.GetLotCount(lastUnloadLotNo);
-                        var getUnLoadDataCountResult = UnLoadService.GetLotCount(lastUnloadLotNo);
+                service.GetMESObject("L223456789" , "03640344");
 
-                        if (getLoadDataCountResult.Result && getUnLoadDataCountResult.Result)
-                        {
-                            var loadDataCount = getLoadDataCountResult.Value;
-                            var unLoadDataCountResult = getUnLoadDataCountResult.Value;
-
-                            if (loadDataCount != unLoadDataCountResult)
-                            {
-                                var alarmCode = 0000;
-
-                                Console.WriteLine(String.Format("LastLotNo:{0} NG", lastUnloadLotNo));
-
-                                //ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(alarmCode));
-                                //CSVAlarmLogService.HappenLog(alarmCode);
-                                //CSVAlarmLogService.DisMissLog(alarmCode);
-                            }
-                            else
-                                Console.WriteLine(String.Format("LastLotNo:{0} OK", lastUnloadLotNo));
-                        }//判斷取得該LotNo LoadData及UnLoadData 數量是否成功
-                        else
-                        {
-
-                        }
-                    }
-                }//判斷本次LotNo 是否與前次LotNo 是否不一致
-            }//判斷取得lastunloadlotNo是否成功判斷
-            else
-            {
-
+                Thread.Sleep(1000);
             }
-
-            #endregion
-
 
             Console.ReadKey();
         }

--- a/TestConsoleApp/Program.cs
+++ b/TestConsoleApp/Program.cs
@@ -19,6 +19,8 @@ using Controller.Interface;
 using Controller;
 using Service.MES.ExObject;
 using Newtonsoft.Json;
+using Common;
+using Service.Device;
 
 namespace TestConsoleApp
 {
@@ -27,13 +29,93 @@ namespace TestConsoleApp
 
         static void Main(string[] args)
         {
-            //var service = MESServiceFactory.Get();
-            var service = CSVServiceFactory.Get<ICSVAlarmLogService>();
+            var deviceService = DeviceServiceFactory.Get(false);
 
-            var r1 = service.HappenLog(123);
-            var r2 = service.DisMissLog(123);
+            while (!deviceService.IsConnect_PLC1)
+            {
+
+                Thread.Sleep(100);
+            }
+
+            deviceService.UpdatePCStatuses(Service.Device.Enums.PCStatuses.DataCountError, true);
+            return;
 
 
+            var CSVservice = CSVServiceFactory.Get<ICSVDeviceService>();
+            CSVservice.Log(DeviceLogSourceTypes.PC, "22000.1", true);
+            CSVservice.Log(DeviceLogSourceTypes.PLC, "22008.1", false, "TestRemarks");
+
+            return;
+
+            var LoadDataService = Service.DataBase.DBServiceFactory.Get<ILoadDataService>();
+            var UnLoadService = Service.DataBase.DBServiceFactory.Get<IUnLoadService>();
+            UnLoadService.GetLastLotNo();
+            //var getlastLotNoResult = unLoadService.GetLastLotNo();
+            //var getUnloadtLotCountResult = loadDataService.GetLotCount("L221028012");
+            //var getloadLotCountResult = unLoadService.GetLotCount("L221028012");
+
+
+            //Console.WriteLine(String.Format("LastLotNo:{0}", getlastLotNoResult.Value));
+            //var lastLotNo = "L221028012";
+            //Console.WriteLine(String.Format("{0} 's LoadData Count :{1}", lastLotNo, getloadLotCountResult.Value));
+            //Console.WriteLine(String.Format("{0} 's UnLoadData Count :{1}", lastLotNo, getUnloadtLotCountResult.Value));
+
+
+            var r1 = new ActResult<UnLoadDataLogDTO>(new UnLoadDataLogDTO() { LotNo = "AAA" });
+            var r2 = new ActResult<UnLoadDataLogDTO>(new UnLoadDataLogDTO() { LotNo = "AAA" });
+
+            #region 下料LotNo比對 
+            var newUnloadLotNo = (r1.Value.LotNo != "DummyLotCode") ? r1.Value.LotNo : r2.Value.LotNo;
+            var lastLotNoResult = UnLoadService.GetLastLotNo();
+            if (lastLotNoResult.Result)
+            {
+                //var lastUnloadLotNo = lastLotNoResult.Value;
+                //var lastUnloadLotNo = "DummyLotCode";
+                //var lastUnloadLotNo = "L221028012";
+                var lastUnloadLotNo = "L220926064";
+                if (lastUnloadLotNo != newUnloadLotNo)
+                {
+                    //DeviceService.UpdatePCStatuses(PCStatuses.ChangeLotNotify, true);
+                    //如果前次lotNo == DummyLotCode 不做總數比對判斷
+                    if (lastUnloadLotNo != "DummyLotCode")
+                    {
+                        var getLoadDataCountResult = LoadDataService.GetLotCount(lastUnloadLotNo);
+                        var getUnLoadDataCountResult = UnLoadService.GetLotCount(lastUnloadLotNo);
+
+                        if (getLoadDataCountResult.Result && getUnLoadDataCountResult.Result)
+                        {
+                            var loadDataCount = getLoadDataCountResult.Value;
+                            var unLoadDataCountResult = getUnLoadDataCountResult.Value;
+
+                            if (loadDataCount != unLoadDataCountResult)
+                            {
+                                var alarmCode = 0000;
+
+                                Console.WriteLine(String.Format("LastLotNo:{0} NG", lastUnloadLotNo));
+
+                                //ThreadPool.QueueUserWorkItem(p => MESService.SendAlarmNotify(alarmCode));
+                                //CSVAlarmLogService.HappenLog(alarmCode);
+                                //CSVAlarmLogService.DisMissLog(alarmCode);
+                            }
+                            else
+                                Console.WriteLine(String.Format("LastLotNo:{0} OK", lastUnloadLotNo));
+                        }//判斷取得該LotNo LoadData及UnLoadData 數量是否成功
+                        else
+                        {
+
+                        }
+                    }
+                }//判斷本次LotNo 是否與前次LotNo 是否不一致
+            }//判斷取得lastunloadlotNo是否成功判斷
+            else
+            {
+
+            }
+
+            #endregion
+
+
+            Console.ReadKey();
         }
     }
 

--- a/TestConsoleApp/TestConsoleApp.csproj
+++ b/TestConsoleApp/TestConsoleApp.csproj
@@ -58,6 +58,10 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Service.Device, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Service.Device\bin\x86\Debug\Service.Device.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/View/Load/EditRecipePage.Designer.cs
+++ b/View/Load/EditRecipePage.Designer.cs
@@ -29,6 +29,7 @@
         private void InitializeComponent()
         {
             this.panel3 = new System.Windows.Forms.Panel();
+            this.Btn_Close = new System.Windows.Forms.Button();
             this.label_ViewMode = new System.Windows.Forms.Label();
             this.TextBox_LastChangeDateTime = new System.Windows.Forms.TextBox();
             this.label8 = new System.Windows.Forms.Label();
@@ -77,7 +78,6 @@
             this.label19 = new System.Windows.Forms.Label();
             this.TextBox_PanelCode = new System.Windows.Forms.TextBox();
             this.label20 = new System.Windows.Forms.Label();
-            this.Btn_Close = new System.Windows.Forms.Button();
             this.panel3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NumUpDown_Quantity)).BeginInit();
             this.panel1.SuspendLayout();
@@ -129,6 +129,22 @@
             this.panel3.Name = "panel3";
             this.panel3.Size = new System.Drawing.Size(974, 808);
             this.panel3.TabIndex = 11;
+            // 
+            // Btn_Close
+            // 
+            this.Btn_Close.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
+            this.Btn_Close.BackgroundImage = global::View.Properties.Resources.Cancel_48;
+            this.Btn_Close.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            this.Btn_Close.Cursor = System.Windows.Forms.Cursors.Arrow;
+            this.Btn_Close.FlatAppearance.BorderSize = 0;
+            this.Btn_Close.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.Btn_Close.Location = new System.Drawing.Point(909, 3);
+            this.Btn_Close.Name = "Btn_Close";
+            this.Btn_Close.Size = new System.Drawing.Size(60, 60);
+            this.Btn_Close.TabIndex = 35;
+            this.Btn_Close.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.Btn_Close.UseVisualStyleBackColor = false;
+            this.Btn_Close.Click += new System.EventHandler(this.Btn_Close_Click);
             // 
             // label_ViewMode
             // 
@@ -760,22 +776,6 @@
             this.label20.Size = new System.Drawing.Size(61, 30);
             this.label20.TabIndex = 5;
             this.label20.Text = "料號";
-            // 
-            // Btn_Close
-            // 
-            this.Btn_Close.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
-            this.Btn_Close.BackgroundImage = global::View.Properties.Resources.Cancel_48;
-            this.Btn_Close.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.Btn_Close.Cursor = System.Windows.Forms.Cursors.Arrow;
-            this.Btn_Close.FlatAppearance.BorderSize = 0;
-            this.Btn_Close.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.Btn_Close.Location = new System.Drawing.Point(909, 3);
-            this.Btn_Close.Name = "Btn_Close";
-            this.Btn_Close.Size = new System.Drawing.Size(60, 60);
-            this.Btn_Close.TabIndex = 35;
-            this.Btn_Close.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.Btn_Close.UseVisualStyleBackColor = false;
-            this.Btn_Close.Click += new System.EventHandler(this.Btn_Close_Click);
             // 
             // EditRecipePage
             // 

--- a/View/Load/EditRecipePage.cs
+++ b/View/Load/EditRecipePage.cs
@@ -129,10 +129,13 @@ namespace View.Load
         }
         private void Btn_OK_Click(object sender, EventArgs e)
         {
-            UpdateRecipe();
+            UpdateRecipe(); 
+            var othermsg = String.Empty;
+
             switch (NowEditMode)
             {
                 case EditMode.Insert:
+
                     var r1 = RecipeController.Create(Recipe, UID);
                     if (!r1.Result)
                     {
@@ -143,11 +146,11 @@ namespace View.Load
                     {
                         var r0 = MESController.SendCreateRecipeNotify(Recipe);
                         if (!r0.Result)
-                            ExMessagePage.Show("通知", String.Format("上拋Recipe至MES失敗,原因:{0}", r0.Exception.Message));
+                            othermsg += String.Format("上拋Recipe至MES失敗,原因:{0}", r0.Exception.Message);
                         else
-                            ExMessagePage.Show("通知", "上拋Recipe至MES成功");
+                            othermsg += "上拋Recipe至MES成功";
                     }
-                    ExMessagePage.Show("新增Recipe 成功", "");
+                    ExMessagePage.Show("新增Recipe 成功", othermsg);
                     Btn_Close.PerformClick();
                     break;
                 case EditMode.Copy:
@@ -161,11 +164,11 @@ namespace View.Load
                     {
                         var r0 = MESController.SendCreateRecipeNotify(Recipe);
                         if (!r0.Result)
-                            ExMessagePage.Show("通知", String.Format("上拋Recipe至MES失敗,原因:{0}", r0.Exception.Message));
+                            othermsg += String.Format("上拋Recipe至MES失敗,原因:{0}", r0.Exception.Message);
                         else
-                            ExMessagePage.Show("通知", "上拋Recipe至MES成功");
+                            othermsg += "上拋Recipe至MES成功";
                     }
-                    ExMessagePage.Show("複製Recipe 成功", "");
+                    ExMessagePage.Show("複製Recipe 成功", othermsg);
                     Btn_Close.PerformClick();
                     break;
                 case EditMode.Edit:

--- a/View/MainFormApp.Designer.cs
+++ b/View/MainFormApp.Designer.cs
@@ -96,7 +96,7 @@
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(98, 24);
             this.label2.TabIndex = 38;
-            this.label2.Text = "Ver 3.3.19";
+            this.label2.Text = "Ver 3.3.20";
             this.label2.Click += new System.EventHandler(this.label2_Click);
             // 
             // button2

--- a/View/MainFormApp.Designer.cs
+++ b/View/MainFormApp.Designer.cs
@@ -96,7 +96,7 @@
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(98, 24);
             this.label2.TabIndex = 38;
-            this.label2.Text = "Ver 3.3.20";
+            this.label2.Text = "Ver 3.3.21";
             this.label2.Click += new System.EventHandler(this.label2_Click);
             // 
             // button2

--- a/View/MainFormApp.Designer.cs
+++ b/View/MainFormApp.Designer.cs
@@ -96,7 +96,7 @@
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(98, 24);
             this.label2.TabIndex = 38;
-            this.label2.Text = "Ver 3.3.15";
+            this.label2.Text = "Ver 3.3.16";
             this.label2.Click += new System.EventHandler(this.label2_Click);
             // 
             // button2

--- a/View/MainFormApp.Designer.cs
+++ b/View/MainFormApp.Designer.cs
@@ -96,7 +96,7 @@
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(98, 24);
             this.label2.TabIndex = 38;
-            this.label2.Text = "Ver 3.3.16";
+            this.label2.Text = "Ver 3.3.19";
             this.label2.Click += new System.EventHandler(this.label2_Click);
             // 
             // button2

--- a/View/MainFormApp.cs
+++ b/View/MainFormApp.cs
@@ -130,6 +130,23 @@ namespace View
             }
 
 
+            var r6 = SettingController.GetLoadDataConfigValue(MainFormApp.IniPath);
+            if (!r6.Result)
+                ExMessagePage.Show("警告", "取得LoadData結束警報秒數失敗將使用預設值。");
+            else
+            {
+                try
+                {
+                    var v1 = r6.Value;
+                    DeviceController.SetLoadDataConfig(v1);
+                }
+                catch (Exception Ex)
+                {
+                    ExMessagePage.Show("警告", "載入LoadData結束警報秒數發生錯誤將加入預設值。" + Ex.Message);
+                }
+            }
+
+
             UpdateConnectTimer.Interval = 250;
             UpdateConnectTimer.Tick += UpdateConnectTimer_Tick;
             UpdateConnectTimer.Start();


### PR DESCRIPTION
3.16 修正內容

1-1 718 資料要求下載過
1-2 719 批號變更批號比對異常 早(150秒內)

2.加入紀錄LPC及PC訊號變動紀錄

3.加入下料LotNo比對
3-1 比對時機為前筆下料lotNo與本次下料LotNo不同時做比對
3-2 對前筆下料LotNo做上料總片數及下料總片數比對

4.修正3.15版本 AlarmLog儲存位置
4-1 D:\CVSlog\Alarm\ >> D:\CSVlog\Alarm\

5.新增/修改配方時除了顯示新增至資料庫結果OKNG，,也會一同顯示發送給MES RecipeCreate結果

6.Servce.DataBase
5-1 LoadDataService 加入 ActResult<int> GetLotCount(string LotCode_) 查詢該LotNo總片數 5-2 UnLoadService  加入 ActResult<int> GetLotCount(string LotCode_) 查詢該LotNo總片數 5-3 UnLoadService 加入 ActResult<string> GetLastLotNo() 取得前一筆下料資料的LotNo

7.Service.Device

6-1 PCStatuses.Empty014 >> PCStatuses.Empty014.ChangeLotNotify 發生下料LotNo變動 6-2 PCStatuses.Empty015 >> PCStatuses.Empty014.DataCountError 發生LotNo上料及下料總片數不一致